### PR TITLE
Fix util.js warn function to not blow up IE11

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 export function warn(...args) {
   if (console && console.warn) {
     if (typeof args[0] === 'string') args[0] = `react-i18next:: ${args[0]}`;
-    console.warn.apply(null, args);
+    console.warn.apply(console, args);
   }
 }
 


### PR DESCRIPTION
It was called with a null which was causing a problem on IE11